### PR TITLE
feat: Add wins/losses delta stats for time period filtering

### DIFF
--- a/src/domain/league/application/use-cases/fetch-all-players.ts
+++ b/src/domain/league/application/use-cases/fetch-all-players.ts
@@ -14,6 +14,8 @@ interface FetchAllPlayersRequest {
 
 export interface PlayerStats {
   pointsLostOrWon: number;
+  winsChange: number;
+  lossesChange: number;
 }
 
 export interface QueueStats {
@@ -111,15 +113,21 @@ export class FetchAllPlayersUseCase {
 
   private calculateStats(snapshots: Snapshot[]): PlayerStats {
     let pointsLostOrWon = 0;
+    let winsChange = 0;
+    let lossesChange = 0;
 
     if (snapshots.length > 0) {
       const first = snapshots[0];
       const last = snapshots[snapshots.length - 1];
       pointsLostOrWon = last.totalPoints - first.totalPoints;
+      winsChange = last.wins - first.wins;
+      lossesChange = last.losses - first.losses;
     }
 
     return {
       pointsLostOrWon,
+      winsChange,
+      lossesChange,
     };
   }
 }

--- a/src/domain/league/application/use-cases/get-player-by-id.ts
+++ b/src/domain/league/application/use-cases/get-player-by-id.ts
@@ -12,6 +12,8 @@ interface GetPlayerByIdRequest {
 
 export interface PlayerStats {
   pointsLostOrWon: number;
+  winsChange: number;
+  lossesChange: number;
 }
 
 export interface QueueStats {
@@ -100,15 +102,21 @@ export class GetPlayerByIdUseCase {
 
   private calculateStats(snapshots: Snapshot[]): PlayerStats {
     let pointsLostOrWon = 0;
+    let winsChange = 0;
+    let lossesChange = 0;
 
     if (snapshots.length > 0) {
       const first = snapshots[0];
       const last = snapshots[snapshots.length - 1];
       pointsLostOrWon = last.totalPoints - first.totalPoints;
+      winsChange = last.wins - first.wins;
+      lossesChange = last.losses - first.losses;
     }
 
     return {
       pointsLostOrWon,
+      winsChange,
+      lossesChange,
     };
   }
 }

--- a/src/infra/http/presenters/player-details-presenter.ts
+++ b/src/infra/http/presenters/player-details-presenter.ts
@@ -5,6 +5,8 @@ import { Snapshot } from '@/domain/league/enterprise/entities/snapshot';
 
 export interface PlayerStats {
   pointsLostOrWon: number;
+  winsChange: number;
+  lossesChange: number;
 }
 
 export interface QueueStats {

--- a/test/fetch-all-players.e2e-spec.ts
+++ b/test/fetch-all-players.e2e-spec.ts
@@ -92,6 +92,8 @@ describe('[GET] /players', () => {
     expect(response.body.data[0].solo.snapshots).toHaveLength(2);
     expect(response.body.data[0].solo.stats).toEqual({
       pointsLostOrWon: 20,
+      winsChange: 0,
+      lossesChange: 0,
     });
   });
 });

--- a/test/get-player-by-id.e2e-spec.ts
+++ b/test/get-player-by-id.e2e-spec.ts
@@ -89,6 +89,8 @@ describe('[GET] /players/:id', () => {
     expect(response.body.data.solo.snapshots).toHaveLength(2);
     expect(response.body.data.solo.stats).toEqual({
       pointsLostOrWon: 20,
+      winsChange: 0,
+      lossesChange: 0,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend `PlayerStats` interface with `winsChange` and `lossesChange` fields
- Update `calculateStats()` to compute deltas from first and last snapshot in date range
- Enables period-based leaderboard filtering (backend support)

## Test plan
- [ ] Run unit tests (`pnpm run test`)
- [ ] Verify API returns `winsChange` and `lossesChange` in stats response
- [ ] Test with different `from`/`to` date parameters

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)